### PR TITLE
feat: Implement API key authentication for Metabase integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,35 @@ This is a TypeScript-based MCP server that implements integration with Metabase 
 
 ## Configuration
 
-Before running the server, you need to set the following environment variables:
+Before running the server, you need to set environment variables for authentication. The server supports two methods:
 
+1.  **API Key (Preferred):**
+    *   `METABASE_URL`: The URL of your Metabase instance (e.g., `https://your-metabase-instance.com`).
+    *   `METABASE_API_KEY`: Your Metabase API key.
+
+2.  **Username/Password (Fallback):**
+    *   `METABASE_URL`: The URL of your Metabase instance.
+    *   `METABASE_USERNAME`: Your Metabase username.
+    *   `METABASE_PASSWORD`: Your Metabase password.
+
+The server will first check for `METABASE_API_KEY`. If it's set, API key authentication will be used. If `METABASE_API_KEY` is not set, the server will fall back to using `METABASE_USERNAME` and `METABASE_PASSWORD`. You must provide credentials for at least one of these methods.
+
+**Example setup:**
+
+Using API Key:
+```bash
+# Required environment variables
+export METABASE_URL=https://your-metabase-instance.com
+export METABASE_API_KEY=your_metabase_api_key
+```
+
+Or, using Username/Password:
 ```bash
 # Required environment variables
 export METABASE_URL=https://your-metabase-instance.com
 export METABASE_USERNAME=your_username
 export METABASE_PASSWORD=your_password
 ```
-
 You can set these environment variables in your shell profile or use a `.env` file with a package like `dotenv`.
 
 ## Development
@@ -69,8 +89,11 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
       "command": "/path/to/metabase-server/build/index.js",
       "env": {
         "METABASE_URL": "https://your-metabase-instance.com",
-        "METABASE_USERNAME": "your_username",
-        "METABASE_PASSWORD": "your_password"
+        // Use API Key (preferred)
+        "METABASE_API_KEY": "your_metabase_api_key"
+        // Or Username/Password (if API Key is not set)
+        // "METABASE_USERNAME": "your_username",
+        // "METABASE_PASSWORD": "your_password"
       }
     }
   }
@@ -96,3 +119,40 @@ npm run inspector
 ```
 
 The Inspector will provide a URL to access debugging tools in your browser.
+
+## Testing
+
+After configuring the environment variables as described in the "Configuration" section, you can manually test the server's authentication. The MCP Inspector (`npm run inspector`) is a useful tool for sending requests to the server.
+
+### 1. Testing with API Key Authentication
+
+1.  Set the `METABASE_URL` and `METABASE_API_KEY` environment variables with your Metabase instance URL and a valid API key.
+2.  Ensure `METABASE_USERNAME` and `METABASE_PASSWORD` are unset or leave them, as the API key should take precedence.
+3.  Start the server: `npm run build && node build/index.js` (or use your chosen method for running the server, like via Claude Desktop config).
+4.  Check the server logs. You should see a message indicating that it's using API key authentication (e.g., "Using Metabase API Key for authentication.").
+5.  Using an MCP client or the MCP Inspector, try calling a tool, for example, `tools/call` with `{"name": "list_dashboards"}`.
+6.  Verify that the tool call is successful and you receive the expected data.
+
+### 2. Testing with Username/Password Authentication (Fallback)
+
+1.  Ensure the `METABASE_API_KEY` environment variable is unset.
+2.  Set `METABASE_URL`, `METABASE_USERNAME`, and `METABASE_PASSWORD` with valid credentials for your Metabase instance.
+3.  Start the server.
+4.  Check the server logs. You should see a message indicating that it's using username/password authentication (e.g., "Using Metabase username/password for authentication." followed by "Authenticating with Metabase using username/password...").
+5.  Using an MCP client or the MCP Inspector, try calling the `list_dashboards` tool.
+6.  Verify that the tool call is successful.
+
+### 3. Testing Authentication Failures
+
+*   **Invalid API Key:**
+    1.  Set `METABASE_URL` and an invalid `METABASE_API_KEY`. Ensure `METABASE_USERNAME` and `METABASE_PASSWORD` variables are unset.
+    2.  Start the server.
+    3.  Attempt to call a tool (e.g., `list_dashboards`). The tool call should fail, and the server logs might indicate an authentication error from Metabase (e.g., "Metabase API error: Invalid X-API-Key").
+*   **Invalid Username/Password:**
+    1.  Ensure `METABASE_API_KEY` is unset. Set `METABASE_URL` and invalid `METABASE_USERNAME`/`METABASE_PASSWORD`.
+    2.  Start the server.
+    3.  Attempt to call a tool. The tool call should fail due to failed session authentication. The server logs might show "Authentication failed" or "Failed to authenticate with Metabase".
+*   **Missing Credentials:**
+    1.  Unset `METABASE_API_KEY`, `METABASE_USERNAME`, and `METABASE_PASSWORD`. Set only `METABASE_URL`.
+    2.  Attempt to start the server.
+    3.  The server should fail to start and log an error message stating that authentication credentials (either API key or username/password) are required (e.g., "Either (METABASE_URL and METABASE_API_KEY) or (METABASE_URL, METABASE_USERNAME, and METABASE_PASSWORD) environment variables are required").


### PR DESCRIPTION
This commit introduces API key authentication as the preferred method for the Metabase MCP server, enhancing security and flexibility.

Changes include:

1.  **Core Logic (`src/index.ts`):**
    *   Added support for a new `METABASE_API_KEY` environment variable.
    *   The server now attempts to authenticate using the API key if provided.
    *   If `METABASE_API_KEY` is not found, it falls back to the existing username/password authentication (`METABASE_USERNAME`, `METABASE_PASSWORD`).
    *   Updated startup checks to ensure that either an API key or username/password credentials are provided.
    *   Included logging to indicate the active authentication method.

2.  **Documentation (`README.md`):**
    *   Updated the "Configuration" section to include `METABASE_API_KEY` and explain the new authentication hierarchy.
    *   Revised examples in "Configuration" and "Installation" (for `claude_desktop_config.json`) to reflect the API key option.
    *   Added a comprehensive "Testing" section with manual test cases for:
        *   API key authentication.
        *   Username/password fallback.
        *   Authentication failure scenarios (invalid key, invalid credentials, missing credentials).

This change allows you to connect to Metabase using API keys, which is often a more secure and manageable approach than using direct username/password credentials, especially in automated or production environments.