### PR TITLE
feat: return related Metabase URL links in CRUD responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\" && mkdir -p dist && cp build/*.js dist/",
+    "test": "npm run build && node --test test/**/*.test.js",
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js"

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -230,7 +230,7 @@ export function formatCardResult(result: QueryResult, maxRows: number = 50): str
 /**
  * Format generic object response (fallback for CRUD operations)
  */
-export function formatGenericResponse(operation: string, data: any): string {
+export function formatGenericResponse(operation: string, data: any, baseUrl?: string): string {
   let output = `# ${operation} Result\n\n`;
 
   if (typeof data === 'string') {
@@ -241,6 +241,17 @@ export function formatGenericResponse(operation: string, data: any): string {
     // Extract key fields
     if (data.id) output += `- **ID**: ${data.id}\n`;
     if (data.name) output += `- **Name**: ${data.name}\n`;
+
+    if (baseUrl && data.id) {
+      const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
+      const op = operation.toLowerCase();
+      if (op.includes('dashboard')) {
+        output += `- **URL**: ${normalizedBaseUrl}/dashboard/${data.id}\n`;
+      } else if (op.includes('card') || op.includes('question')) {
+        output += `- **URL**: ${normalizedBaseUrl}/question/${data.id}\n`;
+      }
+    }
+
     if (data.created_at) output += `- **Created**: ${new Date(data.created_at).toISOString()}\n`;
     if (data.updated_at) output += `- **Updated**: ${new Date(data.updated_at).toISOString()}\n`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ enum ErrorCode {
 // 自定义错误类
 class McpError extends Error {
   code: ErrorCode;
-  
+
   constructor(code: ErrorCode, message: string) {
     super(message);
     this.code = code;
@@ -121,7 +121,7 @@ class MetabaseServer {
 
     this.setupResourceHandlers();
     this.setupToolHandlers();
-    
+
     // Enhanced error handling with logging
     this.server.onerror = (error: Error) => {
       this.logError('Server Error', error);
@@ -155,7 +155,7 @@ class MetabaseServer {
   private logError(message: string, error: unknown) {
     const errorObj = error as Error;
     const apiError = error as { response?: { data?: { message?: string } }, message?: string };
-    
+
     const logMessage = {
       timestamp: new Date().toISOString(),
       level: 'error',
@@ -189,10 +189,10 @@ class MetabaseServer {
       });
 
       this.sessionToken = response.data.id;
-      
+
       // 设置默认请求头
       this.axiosInstance.defaults.headers.common['X-Metabase-Session'] = this.sessionToken;
-      
+
       this.logInfo('Successfully authenticated with Metabase');
       return this.sessionToken as string;
     } catch (error) {
@@ -217,7 +217,7 @@ class MetabaseServer {
       try {
         // 获取仪表板列表
         const dashboardsResponse = await this.axiosInstance.get('/api/dashboard');
-        
+
         this.logInfo('Successfully listed resources', { count: dashboardsResponse.data.length });
         // 将仪表板作为资源返回
         return {
@@ -278,7 +278,7 @@ class MetabaseServer {
         if ((match = uri.match(/^metabase:\/\/dashboard\/(\d+)$/))) {
           const dashboardId = match[1];
           const response = await this.axiosInstance.get(`/api/dashboard/${dashboardId}`);
-          
+
           return {
             contents: [{
               uri: request.params?.uri,
@@ -287,12 +287,12 @@ class MetabaseServer {
             }]
           };
         }
-        
+
         // 处理问题/卡片资源
         else if ((match = uri.match(/^metabase:\/\/card\/(\d+)$/))) {
           const cardId = match[1];
           const response = await this.axiosInstance.get(`/api/card/${cardId}`);
-          
+
           return {
             contents: [{
               uri: request.params?.uri,
@@ -301,12 +301,12 @@ class MetabaseServer {
             }]
           };
         }
-        
+
         // 处理数据库资源
         else if ((match = uri.match(/^metabase:\/\/database\/(\d+)$/))) {
           const databaseId = match[1];
           const response = await this.axiosInstance.get(`/api/database/${databaseId}`);
-          
+
           return {
             contents: [{
               uri: request.params?.uri,
@@ -315,7 +315,7 @@ class MetabaseServer {
             }]
           };
         }
-        
+
         else {
           throw new McpError(
             ErrorCode.InvalidRequest,
@@ -958,7 +958,7 @@ class MetabaseServer {
               }]
             };
           }
-          
+
           case "execute_query": {
             const databaseId = request.params?.arguments?.database_id;
             const query = request.params?.arguments?.query;
@@ -1026,7 +1026,7 @@ class MetabaseServer {
             return {
               content: [{
                 type: "text",
-                text: formatGenericResponse('Create Card', response.data)
+                text: formatGenericResponse('Create Card', response.data, METABASE_URL)
               }]
             };
           }
@@ -1051,7 +1051,7 @@ class MetabaseServer {
             return {
               content: [{
                 type: "text",
-                text: formatGenericResponse('Update Card', response.data)
+                text: formatGenericResponse('Update Card', response.data, METABASE_URL)
               }]
             };
           }
@@ -1081,7 +1081,7 @@ class MetabaseServer {
               return {
                 content: [{
                   type: "text",
-                  text: formatGenericResponse('Archive Card', response.data)
+                  text: formatGenericResponse('Archive Card', response.data, METABASE_URL)
                 }]
               };
             }
@@ -1106,7 +1106,7 @@ class MetabaseServer {
             return {
               content: [{
                 type: "text",
-                text: formatGenericResponse('Create Dashboard', response.data)
+                text: formatGenericResponse('Create Dashboard', response.data, METABASE_URL)
               }]
             };
           }
@@ -1131,7 +1131,7 @@ class MetabaseServer {
             return {
               content: [{
                 type: "text",
-                text: formatGenericResponse('Update Dashboard', response.data)
+                text: formatGenericResponse('Update Dashboard', response.data, METABASE_URL)
               }]
             };
           }
@@ -1161,7 +1161,7 @@ class MetabaseServer {
               return {
                 content: [{
                   type: "text",
-                  text: formatGenericResponse('Archive Dashboard', response.data)
+                  text: formatGenericResponse('Archive Dashboard', response.data, METABASE_URL)
                 }]
               };
             }

--- a/test/formatters.test.js
+++ b/test/formatters.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatGenericResponse } from '../build/formatters.js';
+
+test('adds question URL for card operations', () => {
+  const result = formatGenericResponse('Create Card', { id: 42, name: 'Revenue' }, 'https://mb.example.com');
+
+  assert.match(result, /\*\*URL\*\*: https:\/\/mb\.example\.com\/question\/42/);
+});
+
+test('adds dashboard URL for dashboard operations', () => {
+  const result = formatGenericResponse('Update Dashboard', { id: 7, name: 'Overview' }, 'https://mb.example.com');
+
+  assert.match(result, /\*\*URL\*\*: https:\/\/mb\.example\.com\/dashboard\/7/);
+});
+
+test('normalizes trailing slash in base URL', () => {
+  const result = formatGenericResponse('Create Card', { id: 99, name: 'Users' }, 'https://mb.example.com/');
+
+  assert.doesNotMatch(result, /\/\/question\/99/);
+  assert.match(result, /\*\*URL\*\*: https:\/\/mb\.example\.com\/question\/99/);
+});
+
+test('does not add URL when id is missing', () => {
+  const result = formatGenericResponse('Create Card', { name: 'No ID' }, 'https://mb.example.com');
+
+  assert.doesNotMatch(result, /\*\*URL\*\*:/);
+});


### PR DESCRIPTION
## Summary
- include direct Metabase URLs in generic CRUD formatter output for cards/questions and dashboards
- pass METABASE_URL through card/dashboard create/update/archive response paths
- normalize trailing slashes in baseUrl to avoid malformed double-slash links
- add tests for card URL, dashboard URL, trailing slash normalization, and missing-id behavior

## Validation
- npm test